### PR TITLE
Check if featuredImage exists before override to avoid JS error

### DIFF
--- a/js/snippets/pte_enable_media.js
+++ b/js/snippets/pte_enable_media.js
@@ -78,11 +78,13 @@
    });
 
    // Set the featuredImage object as `this` for the frame function...
-   oldFeaturedImageFrame = $.proxy( wp.media.featuredImage.frame, wp.media.featuredImage );
-   wp.media.featuredImage.frame = function() {
-      var frame = oldFeaturedImageFrame()
-      frame.setState('library')
-      return frame;
+   if ( typeof wp.media.featuredImage !== 'undefined' ) {
+      oldFeaturedImageFrame = $.proxy( wp.media.featuredImage.frame, wp.media.featuredImage );
+      wp.media.featuredImage.frame = function() {
+         var frame = oldFeaturedImageFrame()
+         frame.setState('library')
+         return frame;
+      }
    }
 
    // Overwrite the MediaFrame.Post class


### PR DESCRIPTION
I'm working with some custom post types which do not have featured image enabled. The plugin throws an error when trying to override featuredImage which is expected since it's not enabled.