### PR TITLE
[feature] Add support for WPML and more plugins.

### DIFF
--- a/php/functions.php
+++ b/php/functions.php
@@ -252,12 +252,25 @@ function pte_body( $id ){
 
 	// Generate an image and put into the ptetmp directory
 	if (false === $editor_image = pte_generate_working_image($id)) {
-		$editor_image = sprintf("%s?action=pte_imgedit_preview&amp;_ajax_nonce=%s&amp;postid=%d&amp;rand=%d",
-			admin_url('admin-ajax.php'),
-			$nonce,
-			$id,
-			rand(1,99999)
-		);
+		if(defined('ICL_SITEPRESS_VERSION'))
+		{
+			$editor_image = sprintf("%s&action=pte_imgedit_preview&amp;_ajax_nonce=%s&amp;postid=%d&amp;rand=%d",
+				admin_url('admin-ajax.php'),
+				$nonce,
+				$id,
+				rand(1,99999)
+			);
+		}
+		else
+		{
+			$editor_image = sprintf("%s?action=pte_imgedit_preview&amp;_ajax_nonce=%s&amp;postid=%d&amp;rand=%d",
+				admin_url('admin-ajax.php'),
+				$nonce,
+				$id,
+				rand(1,99999)
+			);
+		}
+		
 	}
 
 	require( PTE_PLUGINPATH . "html/pte.php" );

--- a/php/functions.php
+++ b/php/functions.php
@@ -252,6 +252,10 @@ function pte_body( $id ){
 
 	// Generate an image and put into the ptetmp directory
 	if (false === $editor_image = pte_generate_working_image($id)) {
+
+		/**
+		 * Check if WPML is installed. If so, we do not use a question mark.
+		 */
 		if(defined('ICL_SITEPRESS_VERSION'))
 		{
 			$editor_image = sprintf("%s&action=pte_imgedit_preview&amp;_ajax_nonce=%s&amp;postid=%d&amp;rand=%d",

--- a/php/functions.php
+++ b/php/functions.php
@@ -254,9 +254,14 @@ function pte_body( $id ){
 	if (false === $editor_image = pte_generate_working_image($id)) {
 
 		/**
-		 * Check if WPML is installed. If so, we do not use a question mark.
+		 * Check if a question mark is included in the URL. If so,
+		 * we use an ampersand rather than a question mark. This 
+		 * fix makes it possible to use WPML.
+		 * 
+		 * @author Daniel Koop <daniel@eenvoudmedia.nl>
 		 */
-		if(defined('ICL_SITEPRESS_VERSION'))
+		
+		if(strpos(admin_url('admin-ajax.php'), '?'))
 		{
 			$editor_image = sprintf("%s&action=pte_imgedit_preview&amp;_ajax_nonce=%s&amp;postid=%d&amp;rand=%d",
 				admin_url('admin-ajax.php'),


### PR DESCRIPTION
When WPML is installed, it adds ?lang=xx to the output of admin_url. This is not supported by post-thumbnail-editor yet and therefore the page where the image can be cropped fails to load.

This pull request checks if the admin_url() returns a question mark. If it does, an ampersand is used rather than a question mark. This makes the plugin compatible with WPML, but also with other third-party plugins who may add a question mark.