### PR TITLE
changed capabilities required to view options page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -52,7 +52,7 @@ Before posting a question or requesting support, disable all other plugins to ve
 If you want to post a problem on the [support forums][wp] or at [github][gh] please include the following information:
 
 1. What browser (and version) are you using, or which browsers have you seen the behavior in?
-2. What wordpress version are you using?
+2. What WordPress version are you using?
 3. Does the javascript console report any exceptions/errors?
    * Google Chrome: ctrl+shift+j
    * Firefox: ctrl+shift+j
@@ -74,6 +74,9 @@ If you want to post a problem on the [support forums][wp] or at [github][gh] ple
 5. Save the resized/recropped images by clicking the save icon.
 
 == Changelog ==
+
+= 2.4.7 =
+* Changed capability for options menu from edit_posts to manage_options 
 
 = 2.4.6 =
 * Updated polish translation

--- a/post-thumbnail-editor.php
+++ b/post-thumbnail-editor.php
@@ -394,14 +394,14 @@ add_action( 'admin_menu', 'pte_admin_menu' );
 function pte_admin_menu(){
 	add_options_page( __('Post Thumbnail Editor', PTE_DOMAIN),
 		__('Post Thumbnail Editor', PTE_DOMAIN),
-		'edit_posts',
+		'manage_options',
 		'pte',
 		'pte_launch_options_page'
 	);
 	// The submenu page function does not put a menu item in the wordpress sidebar.
 	add_submenu_page(NULL, __('Post Thumbnail Editor', PTE_DOMAIN),
 		__('Post Thumbnail Editor', PTE_DOMAIN),
-		'edit_posts',
+		'manage_options',
 		'pte-edit',
 		'pte_edit_page'
 	);
@@ -475,4 +475,3 @@ function pte_wp_ajax_imgedit_preview_wrapper(){
 load_plugin_textdomain( PTE_DOMAIN
 	, false
 	, basename( PTE_PLUGINPATH ) . DIRECTORY_SEPARATOR . "i18n" );
-


### PR DESCRIPTION
The plugins options page was set to be visible for anyone that had edit_post capabilities. This pull request uses more logical the manage_options capabilities.